### PR TITLE
Expose latest snowflake odbc driver 2.25.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ it, with the following in the Aptfile:
 ```
 unix-odbc
 unixodbc-dev <-- required for ruby-odbc gem
-https://raw.githubusercontent.com/drivy/heroku-buildpack-snowflake-odbc/master/snowflake-odbc-2.16.10.x86_64.deb
+https://raw.githubusercontent.com/drivy/heroku-buildpack-snowflake-odbc/master/snowflake-odbc-2.25.4.x86_64.deb
 ```
 
 Add buildpacks


### PR DESCRIPTION
## What?

Adds the new `2.25.4` Snowflake ODBC driver

## Why?

Snowflake ODBC driver `2.16.10` will be deprecated on October 31th

## Todo

- Once we're sure everything works as expected on Rangers production using the new version, remove the deprecated driver from this repo
- Cleanup the useless `odbc.ini` [generated file](https://github.com/drivy/heroku-buildpack-snowflake-odbc/blob/7862af0c2d62ab79ddfec4cd35a82304db8b2519/.profile.d/configure-snowflake-odbc.sh#L6-L17)<br />❓ as it's a public repo, how to be sure no one else is using it ? cleaning the file we're not using anymore on Rangers might be a broken change for someone else